### PR TITLE
Fix installation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "description": "tiny wrapper for mongodb",
   "main": "index.js",
+  "files": [
+    "README.md",
+    "index.js",
+    "commands/compose/dump.js"
+  ],
   "author": "Shuhei KONDO @_dot",
   "repository": "dot/heroku-mongodb",
   "bugs": {


### PR DESCRIPTION
In the current plugin, the following error occurs during installation with the latest version of heroku cli.

```
➜  heroku-mongodb git:(master) heroku -v
heroku/7.7.8 darwin-x64 node-v10.7.0
➜  heroku-mongodb git:(master) heroku plugins:link git/github.com/dot/heroku-mongodb                       
(node:33430) Error Plugin: heroku-mongodb: files attribute must be specified in /Users/katsusuke/git/github.com/dot/heroku-mongodb/package.json
```

I add files attribute to package.json and that error was fixed.

cf https://github.com/heroku/cli/issues/909